### PR TITLE
Remove two unnecessary operations.

### DIFF
--- a/pg_jsonb_delete_op.sql
+++ b/pg_jsonb_delete_op.sql
@@ -12,7 +12,7 @@ $BODY$
         (
             SELECT ('{' || string_agg(to_json(key) || ':' || value, ',') || '}')
             FROM jsonb_each(a)
-            WHERE NOT to_json(key)::jsonb ? b
+            WHERE key <> b
         )
     , '{}')::jsonb;
 $BODY$


### PR DESCRIPTION
<pre>
[[local]:5432] matt@~ =# EXPLAIN ANALYZE SELECT 'x' <> 'x' FROM generate_series(1,100000);
                                                       QUERY PLAN                                                        
-------------------------------------------------------------------------------------------------------------------------
 Function Scan on generate_series  (cost=0.00..10.00 rows=1000 width=0) (actual time=22.346..45.794 rows=100000 loops=1)
 Planning time: 0.042 ms
 Execution time: 59.130 ms
(3 rows)

Time: 59.744 ms
[[local]:5432] matt@~ =# EXPLAIN ANALYZE SELECT 'x' <> 'y' FROM generate_series(1,100000);
                                                       QUERY PLAN                                                        
-------------------------------------------------------------------------------------------------------------------------
 Function Scan on generate_series  (cost=0.00..10.00 rows=1000 width=0) (actual time=21.784..45.676 rows=100000 loops=1)
 Planning time: 0.043 ms
 Execution time: 59.294 ms
(3 rows)

Time: 59.663 ms
</pre>
