### PR TITLE
Use array ALL() function, and remove json/jsonb casts

### DIFF
--- a/pg_jsonb_delete_op.sql
+++ b/pg_jsonb_delete_op.sql
@@ -31,7 +31,7 @@ $BODY$
         (
             SELECT ('{' || string_agg(to_json(key) || ':' || value, ',') || '}')
             FROM jsonb_each(a)
-            WHERE NOT to_json(key)::jsonb ?| b
+            WHERE key <> ALL(b)
         )
     , '{}')::jsonb;
 $BODY$


### PR DESCRIPTION
<pre>
[[local]:5432] matt@~ =# EXPLAIN ANALYZE SELECT to_json('x2'::text)::jsonb ?| ARRAY['x', 'y'] FROM generate_series(1,100000);
                                                        QUERY PLAN                                                        
--------------------------------------------------------------------------------------------------------------------------
 Function Scan on generate_series  (cost=0.00..20.00 rows=1000 width=0) (actual time=23.261..357.720 rows=100000 loops=1)
 Planning time: 0.051 ms
 Execution time: 376.334 ms
(3 rows)

Time: 376.732 ms

[[local]:5432] matt@~ =# EXPLAIN ANALYZE SELECT 'x2' <> ALL( ARRAY['x', 'y']) FROM generate_series(1,100000);
                                                       QUERY PLAN                                                        
-------------------------------------------------------------------------------------------------------------------------
 Function Scan on generate_series  (cost=0.00..12.50 rows=1000 width=0) (actual time=22.687..59.327 rows=100000 loops=1)
 Planning time: 0.112 ms
 Execution time: 71.561 ms
(3 rows)

Time: 72.162 ms
</pre>
