### PR TITLE
Cast key back to text.

### DIFF
--- a/pg_jsonb_delete_op.sql
+++ b/pg_jsonb_delete_op.sql
@@ -50,7 +50,7 @@ $BODY$
         (
             SELECT ('{' || string_agg(to_json(key) || ':' || value, ',') || '}')
             FROM jsonb_each(a)
-            WHERE NOT ('{' || to_json(key) || ':' || value || '}')::jsonb <@ b
+            WHERE NOT ('{' || to_json(key)::text || ':' || value || '}')::jsonb <@ b
         )
     , '{}')::jsonb;
 $BODY$


### PR DESCRIPTION
I needed to make this change to get it to actually allow me to create the function:

<pre>
[[local]:5432] matt@~ =# CREATE OR REPLACE FUNCTION jsonb_delete_left(a jsonb, b jsonb) 
-# RETURNS jsonb AS 
-# $BODY$
$#     SELECT COALESCE(    
$#         (
$#             SELECT ('{' || string_agg(to_json(key) || ':' || value, ',') || '}')
$#             FROM jsonb_each(a)
$#             WHERE NOT ('{' || to_json(key) || ':' || value || '}')::jsonb <@ b
$#         )
$#     , '{}')::jsonb;
$# $BODY$
-# LANGUAGE sql IMMUTABLE STRICT;
ERROR:  invalid input syntax for type json
LINE 6: ...        SELECT ('{' || string_agg(to_json(key) || ':' || val...
                                                             ^
DETAIL:  Expected JSON value, but found ":".
CONTEXT:  JSON data, line 1: :
Time: 1.076 ms
</pre>
